### PR TITLE
Fix broken translation key

### DIFF
--- a/src/main/resources/data/quakecraft/lang/en_us.json
+++ b/src/main/resources/data/quakecraft/lang/en_us.json
@@ -1,5 +1,5 @@
 {
-  "game.quakecraft.quakecraft": "Quakecraft",
+  "gameType.quakecraft.quakecraft": "Quakecraft",
   "quakecraft.game.end.nobody_won": "Nobody has won!",
   "quakecraft.game.end.not_enough_players": "There is not enough players to continue the game.",
   "quakecraft.game.end.win": "%s has won!",


### PR DESCRIPTION
`game.quakecraft.quakecraft` is no longer correct.
This pull request changes it to `gameType.quakecraft.quakecraft`.